### PR TITLE
Explicitly add C++17 to CMakeLists

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,7 +4,7 @@ project(meow-script
     LANGUAGES CXX
     DESCRIPTION "An easy extendable scripting language"
 )
-
+set(CMAKE_CXX_STANDARD 17)
 set(BINARY meow-script)
 set(SOURCE 
     src/commands.cpp


### PR DESCRIPTION
I had trouble compiling it because there wasn't this line in the CMakeLists